### PR TITLE
Add a threshold parameter for prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# IDE
+.vscode/*
+
+# CMake
+build/*

--- a/include/katanoisi/classifier.h
+++ b/include/katanoisi/classifier.h
@@ -14,7 +14,7 @@ public:
   }
 
   std::vector<std::pair<fasttext::real, std::string>>
-  prediction(std::__cxx11::string &text, int count);
+  prediction(std::__cxx11::string &text, int count, float threshold=0.0);
   std::string getDomain() { return _domain; }
 
 private:

--- a/include/katanoisi/rest_server.h
+++ b/include/katanoisi/rest_server.h
@@ -49,7 +49,7 @@ private:
                             Http::ResponseWriter response);
 
   std::vector<std::pair<fasttext::real, std::string>>
-  askClassification(std::string &text, std::string &domain, int count);
+  askClassification(std::string &text, std::string &domain, int count, float threshold);
 
   bool process_localization(string &input, json &output);
 

--- a/src/classifier.cpp
+++ b/src/classifier.cpp
@@ -4,17 +4,16 @@
 #include "katanoisi/classifier.h"
 
 std::vector<std::pair<fasttext::real, std::string>>
-classifier::prediction(std::string &text, int count) {
+classifier::prediction(std::string &text, int count, float threshold) {
   std::vector<std::pair<fasttext::real, std::string>> results;
 
   if (*(text.end() - 1) != '\n')
     text.push_back('\n');
 
   std::stringstream istr(text);
-  _model.predictLine(istr, results, count, 0.0);
+  _model.predictLine(istr, results, count, threshold);
 
   for (auto &r : results) {
-    r.first = exp(r.first);
     // FastText returns labels like : '__label__XX'
     r.second = r.second.substr(9);
   }

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -85,9 +85,13 @@ void rest_server::doClassificationPost(const Rest::Request &request,
   response.headers().add<Http::Header::AccessControlAllowOrigin>("*");
   nlohmann::json j = nlohmann::json::parse(request.body());
   int count = 10;
+  float threshold = 0.0;
   bool debugmode = false;
   if (j.find("count") != j.end()) {
     count = j["count"];
+  }
+  if (j.find("threshold") != j.end()) {
+    threshold = j["threshold"];
   }
   if (j.find("debug") != j.end()) {
     debugmode = j["debug"];
@@ -111,7 +115,7 @@ void rest_server::doClassificationPost(const Rest::Request &request,
         string domain = j["domain"];
         string tokenized = j["tokenized"];
         std::vector<std::pair<fasttext::real, std::string>> results;
-        results = askClassification(tokenized, domain, count);
+        results = askClassification(tokenized, domain, count, threshold);
         j.push_back(
             nlohmann::json::object_t::value_type(string("intention"), results));
       } else {
@@ -141,7 +145,7 @@ void rest_server::doClassificationPost(const Rest::Request &request,
 
 std::vector<std::pair<fasttext::real, std::string>>
 rest_server::askClassification(std::string &text, std::string &domain,
-                               int count) {
+                               int count, float threshold) {
   std::vector<std::pair<fasttext::real, std::string>> to_return;
   if ((int)text.size() > 0) {
     auto it_classif = std::find_if(_list_classifs.begin(), _list_classifs.end(),
@@ -149,7 +153,7 @@ rest_server::askClassification(std::string &text, std::string &domain,
                                      return l_classif->getDomain() == domain;
                                    });
     if (it_classif != _list_classifs.end()) {
-      to_return = (*it_classif)->prediction(text, count);
+      to_return = (*it_classif)->prediction(text, count, threshold);
     }
   }
   return to_return;


### PR DESCRIPTION
Solving #7. We now have a threshold parameter for the classifier that will set a minimum confidence score to return a tag. We also added the `threshold` parameter on the Rest Server `/intention/` route.
By default, the threshold value is 0.