### PR TITLE
Use standard naming for classes + member functions

### DIFF
--- a/include/abstract_server.h
+++ b/include/abstract_server.h
@@ -15,11 +15,11 @@ using namespace std;
 
 class AbstractServer {
 public:
-    AbstractServer(int num_port, string &classif_config, int debug_mode);
+    AbstractServer(int num_port, string& classif_config, int debug_mode);
     virtual ~AbstractServer() {}
-    virtual void init(size_t thr = 2) = 0;
-    virtual void start() = 0;
-    virtual void shutdown() = 0;
+    virtual void Init(size_t thr = 2) = 0;
+    virtual void Start() = 0;
+    virtual void Shutdown() = 0;
 
 protected:
   int _debug_mode;

--- a/include/classifier.h
+++ b/include/classifier.h
@@ -9,20 +9,20 @@
 #include <fasttext/fasttext.h>
 #include "tokenizer.h"
 
-class classifier {
+class Classifier {
 public:
-  classifier(std::string &filename, std::string &domain, std::string &lang) : _domain(domain) {
+  Classifier(std::string& filename, std::string& domain, std::string& lang) : _domain(domain) {
     _model.loadModel(filename.c_str());
-    _tokenizer = unique_ptr<tokenizer>(new tokenizer(lang,true));
+    _tokenizer = unique_ptr<Tokenizer>(new Tokenizer(lang,true));
   }
   std::vector<std::pair<fasttext::real, std::string>>
-  prediction(std::__cxx11::string &text, std::__cxx11::string &tokenized, int count, float threshold=0.0);
-  std::string getDomain() { return _domain; }
+  Predict(std::__cxx11::string& text, std::__cxx11::string& tokenized, int count, float threshold=0.0);
+  std::string GetDomain() { return _domain; }
 
 private:
   std::string _domain;
   fasttext::FastText _model;
-  unique_ptr<tokenizer> _tokenizer;
+  unique_ptr<Tokenizer> _tokenizer;
 };
 
 #endif // __CLASSIFIER_H

--- a/include/classifier_controller.h
+++ b/include/classifier_controller.h
@@ -13,18 +13,18 @@
 
 class ClassifierController {
 public:
-  ClassifierController(std::string &classif_config);
+  ClassifierController(std::string& classif_config);
   ~ClassifierController();
-  std::vector<classifier *> getListClassifs();
-  std::vector<std::pair<fasttext::real, std::string>> askClassification(std::string &text, 
-                                                                      std::string &tokenized,
-                                                                      std::string &domain,
+  std::vector<Classifier *> GetListClassifs();
+  std::vector<std::pair<fasttext::real, std::string>> AskClassification(std::string& text, 
+                                                                      std::string& tokenized,
+                                                                      std::string& domain,
                                                                       int count,
                                                                       float threshold);
 
 private:
-  std::vector<classifier *> _list_classifs;
-  void ProcessConfigFile(std::string &classif_config, std::vector<classifier *> &_list_classifs);
+  std::vector<Classifier *> _list_classifs;
+  void ProcessConfigFile(std::string& classif_config, std::vector<Classifier *>& list_classifs);
 };
 
 #endif // __CLASSIFIER_CONTROLLER_H

--- a/include/grpc_server.h
+++ b/include/grpc_server.h
@@ -26,17 +26,17 @@ using namespace std;
 using namespace nlohmann;
 
 
-class grpc_server : public AbstractServer {//, public RouteClassify::Service {
+class GrpcServer : public AbstractServer {//, public RouteClassify::Service {
 
 public:
     using AbstractServer::AbstractServer;
-    ~grpc_server() {delete _service;}
-    void init(size_t thr = 2) override;
-    void start() override;
-    void shutdown() override;
+    ~GrpcServer() {delete _service;}
+    void Init(size_t thr = 2) override;
+    void Start() override;
+    void Shutdown() override;
 
 private:
-    GrpcRouteClassifyImpl *_service;
+    GrpcRouteClassifyImpl* _service;
 };
 
 #endif // __GRPC_SERVER_H

--- a/include/rest_server.h
+++ b/include/rest_server.h
@@ -23,44 +23,41 @@ using namespace std;
 using namespace nlohmann;
 using namespace Pistache;
 
-class rest_server : public AbstractServer {
+class RestServer : public AbstractServer {
 
 public:
   using AbstractServer::AbstractServer;
-  ~rest_server(){httpEndpoint->shutdown();}
-  void init(size_t thr = 2) override;
-  void start() override;
-  void shutdown() override;
+  ~RestServer(){_http_endpoint->shutdown();}
+  void Init(size_t thr = 2) override;
+  void Start() override;
+  void Shutdown() override;
 
 private:
-  std::shared_ptr<Http::Endpoint> httpEndpoint;
-  Rest::Router router;
-  typedef std::mutex Lock;
-  typedef std::lock_guard<Lock> Guard;
-  Lock nluLock;
+  std::shared_ptr<Http::Endpoint> _http_endpoint;
+  Rest::Router _router;
 
-  void setupRoutes();
+  void SetupRoutes();
 
-  void doClassificationGet(const Rest::Request &request,
+  void DoClassificationGet(const Rest::Request& request,
                            Http::ResponseWriter response);
 
-  void doClassificationPost(const Rest::Request &request,
+  void DoClassificationPost(const Rest::Request& request,
                             Http::ResponseWriter response);
 
-  void doClassificationBatchPost(const Rest::Request &request,
+  void DoClassificationBatchPost(const Rest::Request& request,
                                  Http::ResponseWriter response);
 
-  void fetchParamWithDefault(const json& j,
+  void FetchParamWithDefault(const json& j,
                               string& domain,
                               int& count,
                               float& threshold,
                               bool& debugmode);
 
-  bool process_localization(string &input, json &output);
+  bool Process_localization(string& input, json& output);
 
-  void writeLog(string text_to_log) {}
+  void WriteLog(string text_to_log) {}
 
-  void doAuth(const Rest::Request &request, Http::ResponseWriter response);
+  void DoAuth(const Rest::Request& request, Http::ResponseWriter response);
 };
 
 #endif // __REST_SERVER_H

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -10,18 +10,18 @@
 #include "qnlp/fr_tokenizer.h"
 #include "qnlp/tokenizer.h"
 
-class tokenizer {
+class Tokenizer {
 public:
-  tokenizer(std::string &lang, bool lowercase = true);
-  ~tokenizer(){delete(_tokenizer);};
-  void set_tokenizer(std::string &lang, bool lowercase = true);
+  Tokenizer(std::string& lang, bool lowercase = true);
+  ~Tokenizer(){delete(_tokenizer);};
+  void SetTokenizer(std::string& lang, bool lowercase = true);
 
-  std::vector<std::string> tokenize(std::string &input);
-  std::string tokenize_str(std::string &input);
+  std::vector<std::string> Tokenize(std::string& input);
+  std::string TokenizeStr(std::string& input);
 
 private:
   std::string _lang;
-  qnlp::Tokenizer *_tokenizer;
+  qnlp::Tokenizer* _tokenizer;
 };
 
 #endif // __TOKENIZER_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -17,15 +17,15 @@
 #include "classifier.h"
 
 
-void Split(const std::string &line, std::vector<std::string> &pieces,
+void Split(const std::string& line, std::vector<std::string>& pieces,
            const std::string del);
 
-void printCookies(const Pistache::Http::Request &req);
+void PrintCookies(const Pistache::Http::Request& req);
 
-const std::string currentDateTime();
+const std::string CurrentDateTime();
 
 namespace Generic {
-void handleReady(const Pistache::Rest::Request &req, Pistache::Http::ResponseWriter response);
+void HandleReady(const Pistache::Rest::Request& req, Pistache::Http::ResponseWriter response);
 } // namespace Generic
 
 #endif // __UTILS_H

--- a/src/abstract_server.cpp
+++ b/src/abstract_server.cpp
@@ -3,7 +3,7 @@
 
 #include "abstract_server.h"
 
-AbstractServer::AbstractServer(int num_port, string &classif_config, int debug_mode){
+AbstractServer::AbstractServer(int num_port, string& classif_config, int debug_mode){
   _num_port = num_port;
   _debug_mode = debug_mode;
 

--- a/src/classifier.cpp
+++ b/src/classifier.cpp
@@ -4,16 +4,16 @@
 #include "classifier.h"
 
 std::vector<std::pair<fasttext::real, std::string>>
-classifier::prediction(std::string &text, std::string &tokenized, int count, float threshold) {
+Classifier::Predict(std::string& text, std::string& tokenized, int count, float threshold) {
   std::vector<std::pair<fasttext::real, std::string>> results;
   if (*(text.end() - 1) != '\n')
     text.push_back('\n');
-  tokenized=_tokenizer->tokenize_str(text);
+  tokenized=_tokenizer->TokenizeStr(text);
 
   std::stringstream istr(tokenized);
   _model.predictLine(istr, results, count, threshold);
 
-  for (auto &r : results) {
+  for (auto& r : results) {
     // FastText returns labels like : '__label__XX'
     r.second = r.second.substr(9);
   }

--- a/src/classifier_controller.cpp
+++ b/src/classifier_controller.cpp
@@ -3,12 +3,12 @@
 
 #include "classifier_controller.h"
 
-ClassifierController::ClassifierController(std::string &classif_config) {
+ClassifierController::ClassifierController(std::string& classif_config) {
     ProcessConfigFile(classif_config, _list_classifs);
 }
 
-void ClassifierController::ProcessConfigFile(std::string &classif_config, 
-                                             std::vector<classifier *> &_list_classifs) {
+void ClassifierController::ProcessConfigFile(std::string& classif_config, 
+                                             std::vector<Classifier *>& list_classifs) {
     
   std::ifstream model_config;
   model_config.open(classif_config);
@@ -23,10 +23,10 @@ void ClassifierController::ProcessConfigFile(std::string &classif_config,
   }
 
   for (const auto& modelnode : config){
-    std::string domain=modelnode.first.as<std::string>();
+    std::string domain = modelnode.first.as<std::string>();
     YAML::Node modelinfos = modelnode.second;
-    std::string filename=modelinfos["filename"].as<std::string>();
-    std::string lang=modelinfos["language"].as<std::string>();
+    std::string filename = modelinfos["filename"].as<std::string>();
+    std::string lang = modelinfos["language"].as<std::string>();
 
     if(domain.empty() || filename.empty() || lang.empty()) {
       std::cerr << "[ERROR] Malformed config for ("
@@ -35,10 +35,10 @@ void ClassifierController::ProcessConfigFile(std::string &classif_config,
       continue;
     }
 
-    cout << "[INFO]\t"<< domain << "\t" << filename << "\t" << lang ;
+    cout << "[INFO]\t" << domain << "\t" << filename << "\t" << lang ;
 
     try {
-      classifier* classifier_pointer = new classifier(filename, domain, lang);
+      Classifier* classifier_pointer = new Classifier(filename, domain, lang);
       _list_classifs.push_back(classifier_pointer);
       cout << "\t===> loaded" << endl;
     } catch (std::invalid_argument& inarg) {
@@ -48,21 +48,21 @@ void ClassifierController::ProcessConfigFile(std::string &classif_config,
   }
 }
 
-std::vector<classifier *> ClassifierController::getListClassifs() {
+std::vector<Classifier *> ClassifierController::GetListClassifs() {
     return _list_classifs;
 }
 
 std::vector<std::pair<fasttext::real, std::string>>
-ClassifierController::askClassification(std::string &text, std::string &tokenized, std::string &domain,
+ClassifierController::AskClassification(std::string& text, std::string& tokenized, std::string& domain,
                                int count, float threshold) {
   std::vector<std::pair<fasttext::real, std::string>> to_return;
   if ((int)text.size() > 0) {
       auto it_classif = std::find_if(_list_classifs.begin(), _list_classifs.end(),
-      [&](classifier *l_classif) {
-                                        return l_classif->getDomain() == domain;
+      [&](Classifier* l_classif) {
+                                        return l_classif->GetDomain() == domain;
                                     });
       if (it_classif != _list_classifs.end()) {
-          to_return = (*it_classif)->prediction(text, tokenized, count, threshold);
+          to_return = (*it_classif)->Predict(text, tokenized, count, threshold);
       } else {
           to_return.push_back(std::pair<fasttext::real, std::string>(0.0,"DOMAIN ERROR"));
           // TODO: Deal with DOMAIN ERROR in GRPC

--- a/src/grpc_route_classify_impl.cpp
+++ b/src/grpc_route_classify_impl.cpp
@@ -7,11 +7,11 @@ grpc::Status GrpcRouteClassifyImpl::GetDomains(grpc::ServerContext* context,
                                                const Empty* request,
                                                Domains* response) {
 
-  for (auto& it: _classifier_controller->getListClassifs()) {
-    response->add_domains(it->getDomain());
+  for (auto& it: _classifier_controller->GetListClassifs()) {
+    response->add_domains(it->GetDomain());
   }
   if (_debug_mode)
-    cerr << "[DEBUG]: " << currentDateTime() << "\t" << "GetDomains" << endl;
+    cerr << "[DEBUG]: " << CurrentDateTime() << "\t" << "GetDomains" << endl;
   return grpc::Status::OK;
 }
 
@@ -20,7 +20,7 @@ grpc::Status GrpcRouteClassifyImpl::GetClassif(grpc::ServerContext* context,
                                                TextClassified* response) {
 
   if (_debug_mode) {
-    cerr << "[DEBUG]: " << currentDateTime() << "\t" << "GetClassif";
+    cerr << "[DEBUG]: " << CurrentDateTime() << "\t" << "GetClassif";
     cerr << "\t" << request->text() << "\t";
   }
 
@@ -31,13 +31,13 @@ grpc::Status GrpcRouteClassifyImpl::GetClassif(grpc::ServerContext* context,
   std::string tokenized;
 
   std::vector<std::pair<fasttext::real, std::string>> results;
-  results = _classifier_controller->askClassification(text, tokenized, domain, response->count(), response->threshold());
+  results = _classifier_controller->AskClassification(text, tokenized, domain, response->count(), response->threshold());
   response->set_tokenized(tokenized);
 
   if (_debug_mode)
     cerr << "Labels:";
   for (auto& it: results) {
-    Score *score = response->add_intention();
+    Score* score = response->add_intention();
     score->set_label(it.second);
     score->set_confidence(it.first);
     if (_debug_mode)
@@ -56,7 +56,7 @@ grpc::Status GrpcRouteClassifyImpl::StreamClassify(grpc::ServerContext* context,
   while (stream->Read(&request)) {
 
     if (_debug_mode) {
-      cerr << "[DEBUG]: " << currentDateTime() << "\t" << "StreamClassify";
+      cerr << "[DEBUG]: " << CurrentDateTime() << "\t" << "StreamClassify";
       cerr  << "\t" << request.text() << "\t";
     }
 
@@ -68,13 +68,13 @@ grpc::Status GrpcRouteClassifyImpl::StreamClassify(grpc::ServerContext* context,
     std::string tokenized;
 
     std::vector<std::pair<fasttext::real, std::string>> results;
-    results = _classifier_controller->askClassification(text, tokenized, domain, response.count(), response.threshold());
+    results = _classifier_controller->AskClassification(text, tokenized, domain, response.count(), response.threshold());
     response.set_tokenized(tokenized);
 
     if (_debug_mode)
       cerr << "Labels:";
     for (auto& it: results) {
-      Score *score = response.add_intention();
+      Score* score = response.add_intention();
       score->set_label(it.second);
       score->set_confidence(it.first);
       if (_debug_mode)

--- a/src/grpc_server.cpp
+++ b/src/grpc_server.cpp
@@ -3,11 +3,11 @@
 
 #include "grpc_server.h"
 
-void grpc_server::init(size_t thr){ //TODO: Check how to use thread number in grpc
+void GrpcServer::Init(size_t thr){ //TODO: Check how to use thread number in grpc
   _service = new GrpcRouteClassifyImpl(_classifier_controller, _debug_mode);
 }
 
-void grpc_server::start(){
+void GrpcServer::Start(){
   std::string server_address = "0.0.0.0:" + std::to_string(_num_port);
 
   grpc::ServerBuilder builder;
@@ -19,7 +19,7 @@ void grpc_server::start(){
   server->Wait();
 }
 
-void grpc_server::shutdown(){
+void GrpcServer::Shutdown(){
   // TODO: /!\ can't shutdown from same thread
 }
 

--- a/src/text-classifier.cpp
+++ b/src/text-classifier.cpp
@@ -31,8 +31,8 @@ void usage() {
   exit(1);
 }
 
-void ProcessArgs(int argc, char **argv) {
-  const char *const short_opts = "p:t:f:dhg";
+void ProcessArgs(int argc, char** argv) {
+  const char* const short_opts = "p:t:f:dhg";
   const option long_opts[] = {
       {"port", 1, nullptr, 'p'},         {"threads", 1, nullptr, 't'},
       {"model-config", 1, nullptr, 'f'}, {"debug", 0, nullptr, 'd'},
@@ -49,7 +49,7 @@ void ProcessArgs(int argc, char **argv) {
     case 't':
       if (set_envvar[0]==1)
       {
-          cout << "[INFO]\t" << currentDateTime() << "\tErasing previous value of threads ("<< threads <<"), given by environment variable, with "<< optarg << endl;
+          cout << "[INFO]\t" << CurrentDateTime() << "\tErasing previous value of threads ("<< threads <<"), given by environment variable, with "<< optarg << endl;
       }
       threads = atoi(optarg);
       break;
@@ -57,7 +57,7 @@ void ProcessArgs(int argc, char **argv) {
     case 'p':
       if (set_envvar[1]==1)
       {
-          cout << "[INFO]\t" << currentDateTime() << "\tErasing previous value of port ("<< num_port <<"), given by environment variable, with " << optarg << endl;
+          cout << "[INFO]\t" << CurrentDateTime() << "\tErasing previous value of port ("<< num_port <<"), given by environment variable, with " << optarg << endl;
       }
       num_port = atoi(optarg);
       break;
@@ -65,7 +65,7 @@ void ProcessArgs(int argc, char **argv) {
     case 'g':
       if (set_envvar[2]==1)
       {
-          cout << "[INFO]\t" << currentDateTime() << "\tErasing previous value of gRPC ("<< server_type <<"), given by environment variable, with " << optarg << endl;
+          cout << "[INFO]\t" << CurrentDateTime() << "\tErasing previous value of gRPC ("<< server_type <<"), given by environment variable, with " << optarg << endl;
       }
       server_type = 1;
       break;
@@ -73,7 +73,7 @@ void ProcessArgs(int argc, char **argv) {
     case 'd':
       if (set_envvar[3]==1)
       {
-          cout << "[INFO]\t" << currentDateTime() << "\tErasing previous value of debug ("<< debug <<"), given by environment variable, with " << optarg << endl;
+          cout << "[INFO]\t" << CurrentDateTime() << "\tErasing previous value of debug ("<< debug <<"), given by environment variable, with " << optarg << endl;
       }
       debug = 1;
       break;
@@ -81,7 +81,7 @@ void ProcessArgs(int argc, char **argv) {
     case 'f':
       if (set_envvar[4]==1)
       {
-          cout << "[INFO]\t" << currentDateTime() << "\tErasing previous value of config filename ("<< model_config <<"), given by environment variable, with " << optarg << endl;
+          cout << "[INFO]\t" << CurrentDateTime() << "\tErasing previous value of config filename ("<< model_config <<"), given by environment variable, with " << optarg << endl;
       }
       model_config = optarg;
       break;
@@ -94,61 +94,61 @@ void ProcessArgs(int argc, char **argv) {
     }
   }
   if (model_config == "") {
-    cerr << "[ERROR]\t" << currentDateTime() << "\tError, you must set a config file" << endl;
+    cerr << "[ERROR]\t" << CurrentDateTime() << "\tError, you must set a config file" << endl;
     usage();
     exit(1);
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   if (getenv("API_TC_THREADS") != NULL) 
   { 
       threads=atoi(getenv("API_TC_THREADS")); 
       set_envvar[0]=1; 
-      cout << "[INFO]\t" << currentDateTime() << "\tSetting the threads value to "<< threads <<", given by environment variable." << endl;
+      cout << "[INFO]\t" << CurrentDateTime() << "\tSetting the threads value to "<< threads <<", given by environment variable." << endl;
   }
   if (getenv("API_TC_PORT") != NULL) 
   { 
       num_port=atoi(getenv("API_TC_PORT")); 
       set_envvar[1]=1; 
-      cout << "[INFO]\t" << currentDateTime() << "\tSetting the port value to "<< num_port <<", given by environment variable." << endl;
+      cout << "[INFO]\t" << CurrentDateTime() << "\tSetting the port value to "<< num_port <<", given by environment variable." << endl;
   }
   if (getenv("API_TC_GRPC") != NULL) 
   { 
       server_type = atoi(getenv("API_TC_GRPC")); 
       set_envvar[2]=1; 
-      cout << "[INFO]\t" << currentDateTime() << "\tSetting the gRPC value to "<< server_type <<", given by environment variable." << endl;
+      cout << "[INFO]\t" << CurrentDateTime() << "\tSetting the gRPC value to "<< server_type <<", given by environment variable." << endl;
   }
   if (getenv("API_TC_DEBUG") != NULL) 
   { 
       debug = atoi(getenv("API_TC_DEBUG")); 
       set_envvar[3]=1; 
-      cout << "[INFO]\t" << currentDateTime() << "\tSetting the debug value to "<< debug <<", given by environment variable." << endl;
+      cout << "[INFO]\t" << CurrentDateTime() << "\tSetting the debug value to "<< debug <<", given by environment variable." << endl;
   }
   if (getenv("API_TC_CONFIG") != NULL) 
   { 
       model_config=getenv("API_TC_CONFIG"); 
       set_envvar[4]=1; 
-      cout << "[INFO]\t" << currentDateTime() << "\tSetting the config filename value to "<< model_config <<", given by environment variable." << endl;
+      cout << "[INFO]\t" << CurrentDateTime() << "\tSetting the config filename value to "<< model_config <<", given by environment variable." << endl;
   }
 
   ProcessArgs(argc, argv);
 
-  cout << "[INFO]\t" << currentDateTime() << "\tCores = " << hardware_concurrency() << endl;
-  cout << "[INFO]\t" << currentDateTime() << "\tUsing " << threads << " threads" << endl;
-  cout << "[INFO]\t" << currentDateTime() << "\tUsing port " << num_port << endl;
-  cout << "[INFO]\t" << currentDateTime() << "\tUsing config file " << model_config << endl;
+  cout << "[INFO]\t" << CurrentDateTime() << "\tCores = " << hardware_concurrency() << endl;
+  cout << "[INFO]\t" << CurrentDateTime() << "\tUsing " << threads << " threads" << endl;
+  cout << "[INFO]\t" << CurrentDateTime() << "\tUsing port " << num_port << endl;
+  cout << "[INFO]\t" << CurrentDateTime() << "\tUsing config file " << model_config << endl;
 
   unique_ptr<AbstractServer> classification_api;
 
   if (server_type == 0) {
-    cout << "[INFO]\t" << currentDateTime() << "\tUsing REST API" << endl;
-    classification_api = std::unique_ptr<rest_server>(new rest_server(num_port, model_config, debug));
+    cout << "[INFO]\t" << CurrentDateTime() << "\tUsing REST API" << endl;
+    classification_api = std::unique_ptr<RestServer>(new RestServer(num_port, model_config, debug));
   } else {
-    cout << "[INFO]\t" << currentDateTime() << "\tUsing gRPC API" << endl;
-    classification_api = std::unique_ptr<grpc_server>(new grpc_server(num_port, model_config, debug));
+    cout << "[INFO]\t" << CurrentDateTime() << "\tUsing gRPC API" << endl;
+    classification_api = std::unique_ptr<GrpcServer>(new GrpcServer(num_port, model_config, debug));
   }
-  classification_api->init(threads); //TODO: Use threads number
-  classification_api->start();
-  classification_api->shutdown();
+  classification_api->Init(threads); //TODO: Use threads number
+  classification_api->Start();
+  classification_api->Shutdown();
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -3,11 +3,11 @@
 
 #include "tokenizer.h"
 
-tokenizer::tokenizer(std::string &lang, bool lowercase) {
-  this->set_tokenizer(lang, lowercase);
+Tokenizer::Tokenizer(std::string& lang, bool lowercase) {
+  this->SetTokenizer(lang, lowercase);
 }
 
-void tokenizer::set_tokenizer(std::string &lang, bool lowercase) {
+void Tokenizer::SetTokenizer(std::string& lang, bool lowercase) {
   _lang = lang;
 
   if (_lang == "fr") {
@@ -22,10 +22,10 @@ void tokenizer::set_tokenizer(std::string &lang, bool lowercase) {
   }
 }
 
-std::vector<std::string> tokenizer::tokenize(std::string &input) {
+std::vector<std::string> Tokenizer::Tokenize(std::string& input) {
   return _tokenizer->tokenize_sentence(input);
 }
 
-std::string tokenizer::tokenize_str(std::string &input) {
+std::string Tokenizer::TokenizeStr(std::string& input) {
   return _tokenizer->tokenize_sentence_to_string(input);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,18 +3,18 @@
 
 #include "utils.h"
 
-void printCookies(const Pistache::Http::Request &req) {
+void PrintCookies(const Pistache::Http::Request &req) {
   auto cookies = req.cookies();
   const std::string indent(4, ' ');
 
   std::cout << "Cookies: [" << std::endl;
-  for (const auto &c : cookies) {
+  for (const auto& c : cookies) {
     std::cout << indent << c.name << " = " << c.value << std::endl;
   }
   std::cout << "]" << std::endl;
 }
 
-void Split(const std::string &line, std::vector<std::string> &pieces,
+void Split(const std::string& line, std::vector<std::string>& pieces,
            const std::string del) {
   size_t begin = 0;
   size_t pos = 0;
@@ -35,7 +35,7 @@ void Split(const std::string &line, std::vector<std::string> &pieces,
     pieces.push_back(token);
 }
 
-const std::string currentDateTime() {
+const std::string CurrentDateTime() {
   time_t now = time(0);
   struct tm tstruct;
   char buf[80];
@@ -48,7 +48,7 @@ const std::string currentDateTime() {
 }
 
 namespace Generic {
-void handleReady(const Pistache::Rest::Request &req, Pistache::Http::ResponseWriter response) {
+void HandleReady(const Pistache::Rest::Request& req, Pistache::Http::ResponseWriter response) {
   response.send(Pistache::Http::Code::Ok, "1");
 }
 } // namespace Generic


### PR DESCRIPTION
Solving #26.
Now all functions (and member functions) are upper camel case. Same for all classes.
And class variable member are lowercased and underscore-separated with a final trailing underscore.