### PR TITLE
Enable DefaultHealthCheckService + Add grpc_health_probe

### DIFF
--- a/src/grpc_route_classify_impl.cpp
+++ b/src/grpc_route_classify_impl.cpp
@@ -108,4 +108,5 @@ void GrpcRouteClassifyImpl::PrepareOutput(const TextToClassify* request, TextCla
 GrpcRouteClassifyImpl::GrpcRouteClassifyImpl(shared_ptr<ClassifierController> classifier_controller, int debug_mode) {
   _classifier_controller = classifier_controller;
   _debug_mode = debug_mode;
+  grpc::EnableDefaultHealthCheckService(true);
 }


### PR DESCRIPTION
Solving #30.

Add Default Health Check Service to gRPC server.
Also ship the grpc_health_probe binary to check health.
See https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/ for more info.