### PR TITLE
Add `classify` rest route instead of `intention`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Text Classifier
 =========
 
-A new C++ API for Intention classification at Qwant Research.
+A new C++ API for text classification at Qwant Research.
 The API is based on [`fasttext`](https://fasttext.cc/).
 
 ## Installation

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -111,6 +111,7 @@ void rest_server::doClassificationPost(
         }
     }
     j.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
+    j.push_back(nlohmann::json::object_t::value_type(string("intention"), results));
     j.push_back(nlohmann::json::object_t::value_type(string("classification"), results));
     std::string s = j.dump();
     if (_debug_mode != 0)
@@ -163,6 +164,7 @@ void rest_server::doClassificationBatchPost(
             }
         }
         it.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
+        it.push_back(nlohmann::json::object_t::value_type(string("intention"), results));
         it.push_back(nlohmann::json::object_t::value_type(string("classification"), results));
       } else {
         response.headers().add<Http::Header::ContentType>(

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -24,6 +24,16 @@ void rest_server::start() {
 void rest_server::setupRoutes() {
   using namespace Rest;
 
+  Routes::Post(router, "/classify/",
+               Routes::bind(&rest_server::doClassificationPost, this));
+
+  Routes::Post(router, "/classify_batch/",
+              Routes::bind(&rest_server::doClassificationBatchPost, this));
+
+  Routes::Get(router, "/classify/",
+              Routes::bind(&rest_server::doClassificationGet, this));
+
+  // For backward compatibality
   Routes::Post(router, "/intention/",
                Routes::bind(&rest_server::doClassificationPost, this));
 
@@ -101,7 +111,7 @@ void rest_server::doClassificationPost(
         }
     }
     j.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
-    j.push_back(nlohmann::json::object_t::value_type(string("intention"), results));
+    j.push_back(nlohmann::json::object_t::value_type(string("classification"), results));
     std::string s = j.dump();
     if (_debug_mode != 0)
       cerr << "[DEBUG]\t" << currentDateTime() << "\tRESPONSE\t" << s << endl;
@@ -153,7 +163,7 @@ void rest_server::doClassificationBatchPost(
             }
         }
         it.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
-        it.push_back(nlohmann::json::object_t::value_type(string("intention"), results));
+        it.push_back(nlohmann::json::object_t::value_type(string("classification"), results));
       } else {
         response.headers().add<Http::Header::ContentType>(
             MIME(Application, Json));


### PR DESCRIPTION
In order to give a more generic name to the rest route, we added the `classify` route.
We kept `intention` for backward compatibility.